### PR TITLE
cnat-client-go: enable status subresource

### DIFF
--- a/cnat-client-go/artifacts/examples/cnat-crd.yaml
+++ b/cnat-client-go/artifacts/examples/cnat-crd.yaml
@@ -9,3 +9,5 @@ spec:
     kind: At
     plural: ats
   scope: Namespaced
+  subresources:
+    status: {}


### PR DESCRIPTION
This PR enables status subresource for `At` CRD in cnat-client-go example.

Without status subresource enabled, status updates fail since it cannot be found https://github.com/programming-kubernetes/cnat/blob/master/cnat-client-go/controller.go#L295