### PR TITLE
cnat-client-go: add missing default case log format argument

### DIFF
--- a/cnat-client-go/controller.go
+++ b/cnat-client-go/controller.go
@@ -286,7 +286,7 @@ func (c *Controller) syncHandler(key string) (time.Duration, error) {
 		klog.Infof("instance %s: phase: DONE", key)
 		return time.Duration(0), nil
 	default:
-		klog.Infof("instance %s: NOP")
+		klog.Infof("instance %s: NOP", key)
 		return time.Duration(0), nil
 	}
 


### PR DESCRIPTION
Infof format %s reads arg #1, but call has 0 args.