### PR TITLE
cnat-kubebuilder: enable status subresource

### DIFF
--- a/cnat-kubebuilder/config/crds/cnat_v1alpha1_at.yaml
+++ b/cnat-kubebuilder/config/crds/cnat_v1alpha1_at.yaml
@@ -11,6 +11,8 @@ spec:
     kind: At
     plural: ats
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/cnat-kubebuilder/pkg/apis/cnat/v1alpha1/at_types.go
+++ b/cnat-kubebuilder/pkg/apis/cnat/v1alpha1/at_types.go
@@ -49,6 +49,7 @@ type AtStatus struct {
 
 // At is the Schema for the ats API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type At struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This PR enables status subresource for `At` CRD in cnat-kubebuilder example.

Without status subresource enabled, status updates fail since it cannot be found https://github.com/programming-kubernetes/cnat/blob/master/cnat-kubebuilder/pkg/controller/at/at_controller.go#L180