### PR TITLE
cnat-kubebuilder: fix schedule parsing log context

### DIFF
--- a/cnat-kubebuilder/pkg/controller/at/at_controller.go
+++ b/cnat-kubebuilder/pkg/controller/at/at_controller.go
@@ -132,7 +132,7 @@ func (r *ReconcileAt) Reconcile(request reconcile.Request) (reconcile.Result, er
 			// Error reading the schedule. Wait until it is fixed.
 			return reconcile.Result{}, err
 		}
-		reqLogger.Info("Schedule parsing done", "Result", "diff", fmt.Sprintf("%v", d))
+		reqLogger.Info("Schedule parsing done", "Result", fmt.Sprintf("diff=%v", d))
 		if d > 0 {
 			// Not yet time to execute the command, wait until the scheduled time
 			return reconcile.Result{RequeueAfter: d}, nil


### PR DESCRIPTION
Logging schedule parsing result was panicing with `odd number of arguments passed as key-value pairs for logging` since after log message even number of arguments, key-value pairs, is expected while odd number of arguments was provided.

Example log line before this PR:
```
{"level":"dpanic","ts":1577040820.1164706,"logger":"controller","msg":"odd number of arguments passed as key-value pairs for logging","namespace":"cnat","at":"example-at","ignored key":"-1h51m40.11646569s","stacktrace":"github.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/github.com/go-logr/zapr.handleFields\n\t/home/foo/go/src/github.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/github.com/go-logr/zapr/zapr.go:106\ngithub.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/github.com/go-logr/zapr.(*infoLogger).Info\n\t/home/foo/go/src/github.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/github.com/go-logr/zapr/zapr.go:70\ngithub.com/programming-kubernetes/cnat/cnat-kubebuilder/pkg/controller/at.(*ReconcileAt).Reconcile\n\t/home/foo/go/src/github.com/programming-kubernetes/cnat/cnat-kubebuilder/pkg/controller/at/at_controller.go:135\ngithub.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/foo/go/src/github.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:215\ngithub.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/home/foo/go/src/github.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\ngithub.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/home/foo/go/src/github.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\ngithub.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/foo/go/src/github.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\ngithub.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/home/foo/go/src/github.com/programming-kubernetes/cnat/cnat-kubebuilder/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

Example log line with this PR:
```
{"level":"info","ts":1577042308.0694482,"logger":"controller","msg":"Schedule parsing done","namespace":"cnat","at":"example-at","Result":"diff=-2h16m28.069431023s"}
```